### PR TITLE
chore(ci): tidy workflows (permissions, concurrency, timeout, pins)  …

### DIFF
--- a/.github/workflows/attic-dryrun.yml
+++ b/.github/workflows/attic-dryrun.yml
@@ -8,9 +8,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   attic-dryrun:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-audit.yml
+++ b/.github/workflows/cleanup-audit.yml
@@ -17,9 +17,15 @@ on:
 permissions:
   contents: read  # đủ để checkout & đọc repo
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cleanup-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
       - name: Checkout

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,9 +5,18 @@ on:
     branches: [ main, master, develop ]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Wave-04: Tidy GitHub Actions Workflows

**Mục tiêu:** Chuẩn hóa các GitHub Actions workflows với permissions, concurrency, timeout và action pins

**Workflows standardized (3 files):**

| Workflow | Before | After |
|----------|--------|-------|
| `attic-dryrun.yml` | ❌ No concurrency/timeout | ✅ Added concurrency + 30min timeout |
| `cleanup-audit.yml` | ❌ No concurrency/timeout | ✅ Added concurrency + 30min timeout |
| `gitleaks.yml` | ❌ No permissions/concurrency/timeout | ✅ Added all standardizations |

**Standardizations added:**
- ✅ **Permissions:** `contents: read` for all workflows
- ✅ **Concurrency:** Prevents overlapping runs with `cancel-in-progress: true`
- ✅ **Timeout:** 30 minutes for all jobs to prevent hanging
- ✅ **Skip CI:** Support for `[skip ci]` in commit messages
- ✅ **Action pins:** Already using stable versions (v4/v5)

**Impact:**
- ✅ **No logic changes** - Only standardization improvements
- ✅ **Better resource management** - Timeout prevents hanging jobs
- ✅ **Improved concurrency** - Prevents overlapping workflow runs
- ✅ **Enhanced security** - Explicit permissions for all workflows

**Checklist:**
- [x] All workflows have standard permissions
- [x] All workflows have concurrency control
- [x] All jobs have timeout limits
- [x] Skip CI support added where appropriate
- [x] No duplicate workflows found
- [x] No logic changes made
- [x] All action versions are stable